### PR TITLE
feat: add planning tools and modernize dashboards

### DIFF
--- a/CODE.gs
+++ b/CODE.gs
@@ -1650,6 +1650,11 @@ function atualizarAgendamento(id, novosDados) {
         if (novosDados.turno) sheet.getRange(rowIndex, BASE_COLUMNS.TURNO).setValue(novosDados.turno);
         if (novosDados.horaInicio) sheet.getRange(rowIndex, BASE_COLUMNS.HORA1).setValue(novosDados.horaInicio);
         if (novosDados.horaFim) sheet.getRange(rowIndex, BASE_COLUMNS.HORA2).setValue(novosDados.horaFim);
+        if (novosDados.especialidade !== undefined) sheet.getRange(rowIndex, BASE_COLUMNS.ESPECIALIDADE).setValue(novosDados.especialidade);
+        if (novosDados.profissional !== undefined) sheet.getRange(rowIndex, BASE_COLUMNS.PROFISSIONAL).setValue(novosDados.profissional);
+        if (novosDados.categoria !== undefined) sheet.getRange(rowIndex, BASE_COLUMNS.CATEGORIA).setValue(novosDados.categoria);
+        if (novosDados.status !== undefined) sheet.getRange(rowIndex, BASE_COLUMNS.STATUS).setValue(novosDados.status);
+        if (novosDados.observacoes !== undefined) sheet.getRange(rowIndex, BASE_COLUMNS.OBSERVACOES).setValue(novosDados.observacoes);
 
         found = true;
         break;

--- a/Index.html
+++ b/Index.html
@@ -10,24 +10,24 @@
       :root {
           --font-family: 'Inter', 'Segoe UI', sans-serif;
           --bg-body: #0f172a;
-          --bg-gradient: radial-gradient(circle at 20% 20%, rgba(99, 102, 241, 0.25), transparent 55%),
-              radial-gradient(circle at 80% 0%, rgba(14, 165, 233, 0.2), transparent 60%),
-              linear-gradient(135deg, #0b1226, #0f172a 55%, #070c1a);
-          --surface-base: #111f3a;
-          --surface-elevated: #182b52;
-          --surface-subtle: #1f345f;
-          --border-soft: rgba(255, 255, 255, 0.08);
-          --border-strong: rgba(255, 255, 255, 0.14);
+          --bg-gradient: radial-gradient(circle at 20% 20%, rgba(99, 102, 241, 0.22), transparent 55%),
+              radial-gradient(circle at 80% 0%, rgba(14, 165, 233, 0.18), transparent 60%),
+              linear-gradient(135deg, #111c3a, #0f172a 55%, #0b1328);
+          --surface-base: #16244a;
+          --surface-elevated: #1d2f5a;
+          --surface-subtle: #243b6f;
+          --border-soft: rgba(255, 255, 255, 0.12);
+          --border-strong: rgba(255, 255, 255, 0.18);
           --text-primary: #f8fafc;
-          --text-secondary: #cbd5f5;
-          --text-muted: #8ca0d0;
-          --primary: #5b7cfd;
-          --primary-soft: rgba(91, 124, 253, 0.12);
-          --primary-strong: #3b5bfd;
-          --success: #48bb78;
-          --info: #38bdf8;
-          --warning: #f59e0b;
-          --danger: #f56565;
+          --text-secondary: #dbe8ff;
+          --text-muted: #9eb4df;
+          --primary: #7a8dff;
+          --primary-soft: rgba(122, 141, 255, 0.18);
+          --primary-strong: #5e73ff;
+          --success: #4ade80;
+          --info: #60a5fa;
+          --warning: #fbbf24;
+          --danger: #f87171;
           --radius-sm: 10px;
           --radius-md: 16px;
           --radius-lg: 22px;
@@ -281,13 +281,12 @@
 
       .main-content {
           display: grid;
-          grid-template-columns: 300px minmax(0, 1fr) 320px;
-          gap: 20px;
+          grid-template-columns: 320px minmax(0, 1fr);
+          gap: 24px;
           align-items: start;
       }
 
-      .sidebar,
-      .indicadores-container {
+      .sidebar {
           background: var(--surface-base);
           border-radius: var(--radius-md);
           border: 1px solid var(--border-soft);
@@ -296,8 +295,7 @@
           position: relative;
       }
 
-      .sidebar h2,
-      .indicadores-container h2 {
+      .sidebar h2 {
           font-size: 1.15rem;
           margin: 0 0 18px;
           display: flex;
@@ -437,6 +435,136 @@
           padding: 24px;
           box-shadow: var(--shadow-soft);
           min-height: 400px;
+      }
+
+      .planejamento-container {
+          background: var(--surface-base);
+          border-radius: var(--radius-md);
+          border: 1px solid var(--border-soft);
+          padding: 24px;
+          box-shadow: var(--shadow-soft);
+          display: flex;
+          flex-direction: column;
+          gap: 16px;
+      }
+
+      .planejamento-header {
+          display: flex;
+          justify-content: space-between;
+          gap: 16px;
+          flex-wrap: wrap;
+          align-items: flex-end;
+      }
+
+      .planejamento-header h2 {
+          margin: 0;
+          color: var(--text-secondary);
+      }
+
+      .planejamento-header p {
+          margin: 4px 0 0;
+          color: var(--text-muted);
+          max-width: 520px;
+      }
+
+      .planejamento-controls {
+          display: flex;
+          gap: 12px;
+          align-items: center;
+          flex-wrap: wrap;
+      }
+
+      .planejamento-controls label {
+          display: flex;
+          flex-direction: column;
+          gap: 6px;
+          color: var(--text-secondary);
+          font-weight: 600;
+      }
+
+      .planejamento-controls select {
+          border-radius: var(--radius-sm);
+          border: 1px solid var(--border-soft);
+          background: var(--surface-elevated);
+          color: var(--text-primary);
+          padding: 10px 12px;
+      }
+
+      .planejamento-table-wrapper {
+          max-height: 320px;
+          overflow: auto;
+          border-radius: var(--radius-sm);
+          border: 1px solid var(--border-soft);
+      }
+
+      .planejamento-table {
+          width: 100%;
+          border-collapse: collapse;
+          color: var(--text-secondary);
+          font-size: 0.92rem;
+      }
+
+      .planejamento-table th,
+      .planejamento-table td {
+          padding: 12px 16px;
+          border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+      }
+
+      .planejamento-table th {
+          text-align: left;
+          position: sticky;
+          top: 0;
+          background: rgba(13, 23, 46, 0.9);
+          backdrop-filter: blur(6px);
+          z-index: 1;
+      }
+
+      .planejamento-table input[type="text"] {
+          width: 100%;
+          border-radius: var(--radius-sm);
+          border: 1px solid var(--border-soft);
+          background: var(--surface-elevated);
+          color: var(--text-primary);
+          padding: 8px 10px;
+      }
+
+      .planejamento-status {
+          display: inline-flex;
+          align-items: center;
+          gap: 6px;
+          padding: 6px 10px;
+          border-radius: 999px;
+          font-weight: 600;
+          font-size: 0.78rem;
+      }
+
+      .planejamento-status.ok {
+          background: rgba(74, 222, 128, 0.22);
+          color: #bbf7d0;
+      }
+
+      .planejamento-status.alerta {
+          background: rgba(248, 113, 113, 0.25);
+          color: #fecaca;
+      }
+
+      .planejamento-status.pendente {
+          background: rgba(96, 165, 250, 0.18);
+          color: #bfdbfe;
+      }
+
+      .planejamento-row-ok {
+          background: rgba(74, 222, 128, 0.12);
+      }
+
+      .planejamento-row-erro {
+          background: rgba(248, 113, 113, 0.12);
+      }
+
+      .planejamento-feedback {
+          min-height: 20px;
+          font-size: 0.9rem;
+          color: var(--text-secondary);
       }
 
       .monitor-header {
@@ -684,15 +812,15 @@
       }
 
       .horario-livre {
-          background: rgba(72, 187, 120, 0.08);
+          background: rgba(74, 222, 128, 0.22);
       }
 
       .horario-ocupado {
-          background: rgba(91, 124, 253, 0.08);
+          background: rgba(122, 141, 255, 0.22);
       }
 
       .horario-bloqueado {
-          background: rgba(245, 101, 101, 0.08);
+          background: rgba(248, 113, 113, 0.24);
       }
 
       .empty-state {
@@ -726,10 +854,10 @@
           border-radius: 4px;
       }
 
-      .color-livre { background: rgba(72, 187, 120, 0.5); }
-      .color-ocupado { background: rgba(91, 124, 253, 0.5); }
-      .color-bloqueado { background: rgba(245, 101, 101, 0.5); }
-      .color-reservado { background: rgba(237, 137, 54, 0.5); }
+      .color-livre { background: rgba(74, 222, 128, 0.65); }
+      .color-ocupado { background: rgba(122, 141, 255, 0.7); }
+      .color-bloqueado { background: rgba(248, 113, 113, 0.7); }
+      .color-reservado { background: rgba(250, 204, 21, 0.7); }
 
       .indicador-card {
           background: var(--surface-elevated);
@@ -774,13 +902,43 @@
           display: block;
       }
 
-      .chart-container,
+      .dashboard-grid {
+          display: grid;
+          grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+          gap: 18px;
+          margin-bottom: 18px;
+      }
+
+      .chart-container {
+          background: var(--surface-elevated);
+          border-radius: var(--radius-md);
+          border: 1px solid var(--border-soft);
+          padding: 18px;
+          box-shadow: var(--shadow-soft);
+          display: flex;
+          flex-direction: column;
+          gap: 12px;
+          min-height: 260px;
+      }
+
+      .chart-container h3 {
+          margin: 0;
+          font-size: 1rem;
+          color: var(--text-secondary);
+      }
+
+      .chart-container canvas {
+          width: 100%;
+          flex: 1;
+      }
+
       .monthly-table,
       .table-card {
           background: var(--surface-elevated);
-          border-radius: var(--radius-sm);
+          border-radius: var(--radius-md);
           border: 1px solid var(--border-soft);
           padding: 18px;
+          box-shadow: var(--shadow-soft);
           margin-bottom: 18px;
       }
 
@@ -1026,10 +1184,10 @@
           font-weight: 600;
       }
 
-      .status-livre { background: rgba(72, 187, 120, 0.2); color: #8ff0b0; }
-      .status-ocupado { background: rgba(91, 124, 253, 0.2); color: #b7c5ff; }
-      .status-bloqueado { background: rgba(245, 101, 101, 0.2); color: #ffb1b1; }
-      .status-reservado { background: rgba(237, 137, 54, 0.2); color: #ffcc99; }
+      .status-livre { background: rgba(74, 222, 128, 0.28); color: #bbf7d0; }
+      .status-ocupado { background: rgba(122, 141, 255, 0.28); color: #d0d8ff; }
+      .status-bloqueado { background: rgba(248, 113, 113, 0.28); color: #fecaca; }
+      .status-reservado { background: rgba(250, 204, 21, 0.28); color: #fef08a; }
 
       .agendamento-details {
           display: grid;
@@ -1071,6 +1229,23 @@
       .btn-mover:hover {
           transform: translateY(-1px);
           box-shadow: 0 8px 16px rgba(56, 189, 248, 0.35);
+      }
+
+      .btn-editar {
+          border: none;
+          border-radius: var(--radius-sm);
+          background: var(--primary);
+          color: #fff;
+          padding: 8px 14px;
+          font-size: 0.85rem;
+          font-weight: 600;
+          cursor: pointer;
+          transition: var(--transition-fast);
+      }
+
+      .btn-editar:hover {
+          transform: translateY(-1px);
+          box-shadow: 0 8px 16px rgba(90, 102, 255, 0.35);
       }
 
       .bloqueio-multiplo {
@@ -1165,14 +1340,7 @@
 
       @media (max-width: 1400px) {
           .main-content {
-              grid-template-columns: 280px minmax(0, 1fr);
-              grid-template-areas:
-                  'sidebar monitor'
-                  'sidebar indicadores';
-          }
-
-          .indicadores-container {
-              grid-column: 1 / -1;
+              grid-template-columns: minmax(0, 1fr);
           }
       }
 
@@ -1195,8 +1363,7 @@
               display: block;
           }
 
-          .sidebar,
-          .indicadores-container {
+          .sidebar {
               position: fixed;
               top: 0;
               right: 0;
@@ -1214,8 +1381,7 @@
               overflow-y: auto;
           }
 
-          .sidebar.drawer-open,
-          .indicadores-container.drawer-open {
+          .sidebar.drawer-open {
               transform: translateX(0);
           }
 
@@ -1355,16 +1521,55 @@
                         <i class="fas fa-sliders-h"></i>
                         <span class="label">Filtros</span>
                     </button>
-                    <button class="icon-button" id="open-insights" type="button" aria-controls="insights-panel" aria-label="Alternar indicadores">
-                        <i class="fas fa-chart-line"></i>
-                        <span class="label">Indicadores</span>
-                    </button>
                     <button class="btn btn-secondary" id="btn-logout" type="button">
                         <i class="fas fa-sign-out-alt"></i> Sair
                     </button>
                 </div>
             </div>
         </header>
+
+        <section class="planejamento-container" id="planejamento-container" style="display: none;">
+            <div class="planejamento-header">
+                <div>
+                    <h2><i class="fas fa-clipboard-check"></i> Planejamento de Salas por Turno</h2>
+                    <p>Monte rapidamente o mapa de salas e valide com o agendamento oficial.</p>
+                </div>
+                <div class="planejamento-controls">
+                    <label>
+                        Turno
+                        <select id="planejamento-turno">
+                            <option value="manha">Manhã</option>
+                            <option value="tarde">Tarde</option>
+                            <option value="noite">Noite</option>
+                            <option value="todos">Todos</option>
+                        </select>
+                    </label>
+                    <button class="btn btn-secondary" id="planejamento-testar" type="button">
+                        <i class="fas fa-vial"></i> Testar atribuições
+                    </button>
+                    <button class="btn btn-primary" id="planejamento-aplicar" type="button">
+                        <i class="fas fa-check-double"></i> Substituir tudo
+                    </button>
+                </div>
+            </div>
+            <div class="planejamento-table-wrapper">
+                <table class="planejamento-table">
+                    <thead>
+                        <tr>
+                            <th>Profissional</th>
+                            <th>Especialidade</th>
+                            <th>Turno</th>
+                            <th>Sala atual</th>
+                            <th>Sala planejada</th>
+                            <th>Status</th>
+                            <th>Ações</th>
+                        </tr>
+                    </thead>
+                    <tbody id="planejamento-tbody"></tbody>
+                </table>
+            </div>
+            <div class="planejamento-feedback" id="planejamento-feedback"></div>
+        </section>
 
         <div class="main-content">
             <aside class="sidebar" data-drawer="filters" id="filters-panel">
@@ -1512,29 +1717,31 @@
                             <span class="resumo-valor" id="dashboard-resumo-salas-consideradas">0</span>
                         </div>
                     </div>
-                    <div class="chart-container">
-                        <h3>Ocupação por Turno</h3>
-                        <canvas id="chart-turno"></canvas>
-                    </div>
-                    <div class="chart-container">
-                        <h3>Ocupação por Ilha</h3>
-                        <canvas id="chart-ilha"></canvas>
-                    </div>
-                    <div class="chart-container">
-                        <h3>Evolução de Ocupação</h3>
-                        <canvas id="chart-evolucao"></canvas>
-                    </div>
-                    <div class="chart-container">
-                        <h3>Distribuição por Especialidade</h3>
-                        <canvas id="chart-especialidade"></canvas>
-                    </div>
-                    <div class="chart-container">
-                        <h3>Distribuição Geral de Ocupação</h3>
-                        <canvas id="chart-heatmap"></canvas>
-                    </div>
-                    <div class="chart-container">
-                        <h3>Distribuição por Status</h3>
-                        <canvas id="chart-aproveitamento"></canvas>
+                    <div class="dashboard-grid">
+                        <div class="chart-container">
+                            <h3>Ocupação por Turno</h3>
+                            <canvas id="chart-turno"></canvas>
+                        </div>
+                        <div class="chart-container">
+                            <h3>Ocupação por Ilha</h3>
+                            <canvas id="chart-ilha"></canvas>
+                        </div>
+                        <div class="chart-container">
+                            <h3>Evolução de Ocupação</h3>
+                            <canvas id="chart-evolucao"></canvas>
+                        </div>
+                        <div class="chart-container">
+                            <h3>Distribuição por Especialidade</h3>
+                            <canvas id="chart-especialidade"></canvas>
+                        </div>
+                        <div class="chart-container">
+                            <h3>Distribuição Geral de Ocupação</h3>
+                            <canvas id="chart-heatmap"></canvas>
+                        </div>
+                        <div class="chart-container">
+                            <h3>Distribuição por Status</h3>
+                            <canvas id="chart-aproveitamento"></canvas>
+                        </div>
                     </div>
                 </div>
 
@@ -1644,54 +1851,6 @@
                 </div>
             </div>
 
-            <aside class="indicadores-container" data-drawer="insights" id="insights-panel">
-                <button class="drawer-close" type="button" data-drawer-close="insights" aria-label="Fechar indicadores">
-                    <i class="fas fa-times"></i>
-                </button>
-                <h2><i class="fas fa-chart-bar"></i> Indicadores</h2>
-                <div class="indicador-card">
-                    <h3><i class="fas fa-chart-pie"></i> Resumo Geral</h3>
-                    <div class="indicador-item">
-                        <span>Total de Salas:</span>
-                        <span class="indicador-valor" id="total-salas">0</span>
-                    </div>
-                    <div class="indicador-item">
-                        <span>Salas Ocupadas:</span>
-                        <span class="indicador-valor" id="salas-ocupadas">0</span>
-                    </div>
-                    <div class="indicador-item">
-                        <span>Salas Livres:</span>
-                        <span class="indicador-valor" id="salas-livres">0</span>
-                    </div>
-                    <div class="indicador-item">
-                        <span>Taxa de Ocupação:</span>
-                        <span class="indicador-valor" id="taxa-ocupacao">0%</span>
-                    </div>
-                </div>
-                
-                <div class="indicador-card">
-                    <h3><i class="fas fa-clock"></i> Por Turno</h3>
-                    <div class="indicador-item">
-                        <span>Manhã:</span>
-                        <span class="indicador-valor" id="ocupacao-manha">0%</span>
-                    </div>
-                    <div class="indicador-item">
-                        <span>Tarde:</span>
-                        <span class="indicador-valor" id="ocupacao-tarde">0%</span>
-                    </div>
-                    <div class="indicador-item">
-                        <span>Noite:</span>
-                        <span class="indicador-valor" id="ocupacao-noite">0%</span>
-                    </div>
-                </div>
-                
-                <div class="indicador-card">
-                    <h3><i class="fas fa-map-pin"></i> Por Ilha e Especialidade</h3>
-                    <div id="ilhas-especialidades-list">
-                        <p>Carregando...</p>
-                    </div>
-                </div>
-            </aside>
         </div>
     </div>
 
@@ -1969,6 +2128,72 @@
         </div>
     </div>
 
+    <div class="modal" id="editar-modal">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h2><i class="fas fa-user-edit"></i> Editar Informações do Agendamento</h2>
+                <button class="close-modal">&times;</button>
+            </div>
+            <div class="modal-body">
+                <div class="alert alert-error" id="editar-alert" style="display: none;">
+                    <i class="fas fa-exclamation-triangle"></i> <span id="editar-message"></span>
+                </div>
+                <form id="form-editar">
+                    <div class="form-group">
+                        <label for="editar-profissional"><i class="fas fa-user-md"></i> Profissional</label>
+                        <input type="text" id="editar-profissional" required>
+                    </div>
+                    <div class="form-group">
+                        <label for="editar-especialidade"><i class="fas fa-stethoscope"></i> Especialidade</label>
+                        <select id="editar-especialidade" required></select>
+                    </div>
+                    <div class="form-group">
+                        <label for="editar-categoria"><i class="fas fa-tag"></i> Categoria</label>
+                        <select id="editar-categoria" required></select>
+                    </div>
+                    <div class="form-group">
+                        <label for="editar-status"><i class="fas fa-circle"></i> Status</label>
+                        <select id="editar-status" required>
+                            <option value="ocupado">Ocupado</option>
+                            <option value="reservado">Reservado</option>
+                            <option value="bloqueado">Bloqueado</option>
+                            <option value="livre">Livre</option>
+                        </select>
+                    </div>
+                    <div class="form-group">
+                        <label for="editar-turno"><i class="fas fa-clock"></i> Turno</label>
+                        <select id="editar-turno" required>
+                            <option value="manha">Manhã</option>
+                            <option value="tarde">Tarde</option>
+                            <option value="noite">Noite</option>
+                            <option value="todos">Integral</option>
+                        </select>
+                    </div>
+                    <div class="form-group">
+                        <label for="editar-hora-inicio"><i class="fas fa-hourglass-start"></i> Hora Início</label>
+                        <input type="time" id="editar-hora-inicio" required>
+                    </div>
+                    <div class="form-group">
+                        <label for="editar-hora-fim"><i class="fas fa-hourglass-end"></i> Hora Fim</label>
+                        <input type="time" id="editar-hora-fim" required>
+                    </div>
+                    <div class="form-group form-full">
+                        <label for="editar-observacoes"><i class="fas fa-sticky-note"></i> Observações</label>
+                        <textarea id="editar-observacoes" rows="3"></textarea>
+                    </div>
+                    <div class="form-actions">
+                        <button type="button" class="btn btn-secondary close-modal">
+                            <i class="fas fa-times"></i> Cancelar
+                        </button>
+                        <button type="submit" class="btn btn-primary">
+                            <i class="fas fa-save"></i> Salvar alterações
+                        </button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+
     <input type="date" id="date-picker" class="sr-only-input" aria-hidden="true">
     <div class="drawer-backdrop" id="drawer-backdrop" aria-hidden="true"></div>
 
@@ -2005,7 +2230,10 @@
                 ilha: []
             },
             userRole: null,
-            visualizacaoSimplificada: true  // Novo estado para toggle simplificado
+            visualizacaoSimplificada: true,  // Novo estado para toggle simplificado
+            planejamentoTurno: 'manha',
+            planejamentoLinhas: [],
+            agendamentoEditarId: null
         };
 
         // Utilidades de normalização
@@ -2284,6 +2512,7 @@
                     console.log('Estado atualizado - Salas:', estado.salas.length, 'Agendamentos:', estado.agendamentos.length);
                     atualizarMonitor();
                     atualizarIndicadores();
+                    atualizarPlanejamento();
                     setTimeout(() => {
                         esconderLoading();
                         console.log('Loading escondido - Verificando se monitor está visível');
@@ -2372,6 +2601,17 @@
                 <label><input type="checkbox" value="bloqueado"> Bloqueado</label>
                 <label><input type="checkbox" value="reservado"> Reservado</label>
             `;
+
+            const statusPadrao = ['livre', 'ocupado'];
+            statusPadrao.forEach(valor => {
+                const input = statusOptions.querySelector(`input[value="${valor}"]`);
+                if (input) input.checked = true;
+            });
+            estado.filtros.status = [...statusPadrao];
+            const statusBtn = document.querySelector('#filter-status-multi .multiselect-btn');
+            if (statusBtn) {
+                statusBtn.textContent = `${statusPadrao.length} selecionados`;
+            }
         }
 
         function setupMultiselectListeners() {
@@ -2436,6 +2676,27 @@
                 option.textContent = `Ilha ${ilha}`;
                 ilhaSelect.appendChild(option);
             });
+
+            const editarEspecialidade = document.getElementById('editar-especialidade');
+            const editarCategoria = document.getElementById('editar-categoria');
+            if (editarEspecialidade) {
+                editarEspecialidade.innerHTML = '<option value="">Selecione</option>';
+                estado.dadosMestres.especialidades.forEach(esp => {
+                    const option = document.createElement('option');
+                    option.value = esp;
+                    option.textContent = esp;
+                    editarEspecialidade.appendChild(option);
+                });
+            }
+            if (editarCategoria) {
+                editarCategoria.innerHTML = '<option value="">Selecione</option>';
+                estado.dadosMestres.categorias.forEach(cat => {
+                    const option = document.createElement('option');
+                    option.value = cat;
+                    option.textContent = cat;
+                    editarCategoria.appendChild(option);
+                });
+            }
         }
 
         function configurarEventListeners() {
@@ -2445,8 +2706,10 @@
                     document.querySelectorAll('.turno-btn').forEach(b => b.classList.remove('active'));
                     this.classList.add('active');
                     estado.turnoAtual = this.getAttribute('data-turno');
+                    estado.planejamentoTurno = estado.turnoAtual === 'todos' ? 'todos' : estado.turnoAtual;
                     atualizarMonitor();
                     atualizarIndicadores();
+                    atualizarPlanejamento();
                 });
             });
 
@@ -2634,27 +2897,47 @@
                 e.preventDefault();
                 moverAgendamento();
             });
+
+            const planejamentoTurnoSelect = document.getElementById('planejamento-turno');
+            if (planejamentoTurnoSelect) {
+                planejamentoTurnoSelect.addEventListener('change', function() {
+                    estado.planejamentoTurno = this.value;
+                    atualizarPlanejamento();
+                });
+            }
+
+            const planejamentoTestarBtn = document.getElementById('planejamento-testar');
+            if (planejamentoTestarBtn) {
+                planejamentoTestarBtn.addEventListener('click', testarPlanejamento);
+            }
+
+            const planejamentoAplicarBtn = document.getElementById('planejamento-aplicar');
+            if (planejamentoAplicarBtn) {
+                planejamentoAplicarBtn.addEventListener('click', aplicarPlanejamentoTudo);
+            }
+
+            const formEditar = document.getElementById('form-editar');
+            if (formEditar) {
+                formEditar.addEventListener('submit', function(e) {
+                    e.preventDefault();
+                    salvarEdicaoAgendamento();
+                });
+            }
         }
 
         function setupResponsiveShell() {
             const filtersDrawer = document.querySelector('[data-drawer="filters"]');
-            const insightsDrawer = document.querySelector('[data-drawer="insights"]');
             const backdrop = document.getElementById('drawer-backdrop');
             const openFiltersBtn = document.getElementById('open-filters');
-            const openInsightsBtn = document.getElementById('open-insights');
             const closeButtons = document.querySelectorAll('[data-drawer-close]');
 
             const drawers = {
-                filters: filtersDrawer,
-                insights: insightsDrawer
+                filters: filtersDrawer
             };
 
             function setExpanded(name, expanded) {
                 if (name === 'filters' && openFiltersBtn) {
                     openFiltersBtn.setAttribute('aria-expanded', expanded ? 'true' : 'false');
-                }
-                if (name === 'insights' && openInsightsBtn) {
-                    openInsightsBtn.setAttribute('aria-expanded', expanded ? 'true' : 'false');
                 }
             }
 
@@ -2706,10 +2989,8 @@
             }
 
             if (openFiltersBtn) openFiltersBtn.setAttribute('aria-expanded', 'false');
-            if (openInsightsBtn) openInsightsBtn.setAttribute('aria-expanded', 'false');
 
             if (openFiltersBtn) openFiltersBtn.addEventListener('click', () => toggleDrawer('filters'));
-            if (openInsightsBtn) openInsightsBtn.addEventListener('click', () => toggleDrawer('insights'));
 
             closeButtons.forEach(btn => {
                 const target = btn.getAttribute('data-drawer-close');
@@ -2719,21 +3000,18 @@
             if (backdrop) {
                 backdrop.addEventListener('click', () => {
                     closeDrawer('filters');
-                    closeDrawer('insights');
                 });
             }
 
             window.addEventListener('keydown', event => {
                 if (event.key === 'Escape') {
                     closeDrawer('filters');
-                    closeDrawer('insights');
                 }
             });
 
             window.addEventListener('resize', () => {
                 if (window.innerWidth > 1100) {
                     closeDrawer('filters');
-                    closeDrawer('insights');
                 }
             });
         }
@@ -2881,6 +3159,10 @@
         }
 
         function atualizarIndicadores() {
+            const totalSalasEl = document.getElementById('total-salas');
+            if (!totalSalasEl) {
+                return;
+            }
             const salasFiltradas = estado.salas.filter(s => salaAtendeFiltros(s));
             const totalSalas = salasFiltradas.length;
             
@@ -2929,7 +3211,7 @@
             const taxaOcupacao = totalSalas > 0 ? Math.round((salasOcupadas / totalSalas) * 100) : 0;
             
             // Atualizar indicadores
-            document.getElementById('total-salas').textContent = totalSalas;
+            totalSalasEl.textContent = totalSalas;
             document.getElementById('salas-ocupadas').textContent = salasOcupadas;
             document.getElementById('salas-livres').textContent = salasLivres;
             document.getElementById('taxa-ocupacao').textContent = taxaOcupacao + '%';
@@ -2962,11 +3244,334 @@
             }
         }
 
+        function atualizarPlanejamento() {
+            const container = document.getElementById('planejamento-container');
+            if (!container) return;
+
+            container.style.display = 'flex';
+
+            const dataIso = estado.dataAtual.toISOString().split('T')[0];
+            const turnoSelecionado = estado.planejamentoTurno || 'manha';
+            const linhasAnteriores = Array.isArray(estado.planejamentoLinhas)
+                ? estado.planejamentoLinhas.reduce((acc, item) => {
+                    acc[item.id] = item;
+                    return acc;
+                }, {})
+                : {};
+
+            const agendamentosDia = estado.agendamentos.filter(ag => {
+                if (!ag) return false;
+                if (!statusBloqueiaAgendamento(ag.statusNormalizado || ag.status)) return false;
+                if (!(ag.dataInicio <= dataIso && ag.dataFim >= dataIso)) return false;
+                const turnoAg = ag.turnoNormalizado || normalizarTurno(ag.turno);
+                if (turnoSelecionado === 'todos') {
+                    return ['manha', 'tarde', 'noite', 'todos'].includes(turnoAg);
+                }
+                return turnoAg === turnoSelecionado || turnoAg === 'todos';
+            }).sort((a, b) => {
+                const turnoA = a.turnoNormalizado || normalizarTurno(a.turno) || '';
+                const turnoB = b.turnoNormalizado || normalizarTurno(b.turno) || '';
+                if (turnoA !== turnoB) {
+                    return turnoA.localeCompare(turnoB);
+                }
+                return (a.profissional || '').localeCompare(b.profissional || '', 'pt-BR');
+            });
+
+            estado.planejamentoLinhas = agendamentosDia.map(ag => {
+                const id = String(ag.id);
+                const anterior = linhasAnteriores[id] || {};
+                return {
+                    id,
+                    profissional: ag.profissional || '—',
+                    especialidade: ag.especialidade || '—',
+                    turno: ag.turnoNormalizado || normalizarTurno(ag.turno) || 'manha',
+                    salaAtual: ag.sala != null ? String(ag.sala) : '—',
+                    salaPlanejada: anterior.salaPlanejada || '',
+                    resultado: null,
+                    mensagem: ''
+                };
+            });
+
+            renderPlanejamento();
+        }
+
+        function renderPlanejamento() {
+            const tbody = document.getElementById('planejamento-tbody');
+            const feedback = document.getElementById('planejamento-feedback');
+            const turnoSelect = document.getElementById('planejamento-turno');
+            if (!tbody) return;
+
+            if (turnoSelect) {
+                turnoSelect.value = estado.planejamentoTurno || 'manha';
+            }
+
+            tbody.innerHTML = '';
+
+            if (!Array.isArray(estado.planejamentoLinhas) || estado.planejamentoLinhas.length === 0) {
+                const tr = document.createElement('tr');
+                const td = document.createElement('td');
+                td.colSpan = 7;
+                td.textContent = 'Nenhum agendamento encontrado para o turno selecionado.';
+                tr.appendChild(td);
+                tbody.appendChild(tr);
+                if (feedback) {
+                    feedback.textContent = 'Informe as salas desejadas para validar o planejamento.';
+                    feedback.style.color = 'var(--text-secondary)';
+                }
+                return;
+            }
+
+            estado.planejamentoLinhas.forEach(item => {
+                const tr = document.createElement('tr');
+                if (item.resultado === 'ok') tr.classList.add('planejamento-row-ok');
+                if (item.resultado === 'erro') tr.classList.add('planejamento-row-erro');
+
+                const tdProfissional = document.createElement('td');
+                tdProfissional.textContent = item.profissional;
+
+                const tdEspecialidade = document.createElement('td');
+                tdEspecialidade.textContent = item.especialidade;
+
+                const tdTurno = document.createElement('td');
+                tdTurno.textContent = formatarTurnoLabel(item.turno) || '-';
+
+                const tdSalaAtual = document.createElement('td');
+                tdSalaAtual.textContent = item.salaAtual || '-';
+
+                const tdPlanejada = document.createElement('td');
+                const input = document.createElement('input');
+                input.type = 'text';
+                input.placeholder = 'Sala desejada';
+                input.value = item.salaPlanejada || '';
+                input.dataset.id = item.id;
+                input.addEventListener('input', event => {
+                    const linha = estado.planejamentoLinhas.find(l => l.id === item.id);
+                    if (linha) {
+                        linha.salaPlanejada = event.target.value.trim();
+                        linha.resultado = null;
+                        linha.mensagem = '';
+                    }
+                    renderPlanejamento();
+                });
+                tdPlanejada.appendChild(input);
+
+                const tdStatus = document.createElement('td');
+                const statusSpan = document.createElement('span');
+                statusSpan.className = 'planejamento-status';
+                let textoStatus = 'Aguardando teste';
+                if (item.resultado === 'ok') {
+                    statusSpan.classList.add('ok');
+                    textoStatus = item.mensagem || 'Tudo certo';
+                } else if (item.resultado === 'erro') {
+                    statusSpan.classList.add('alerta');
+                    textoStatus = item.mensagem || 'Divergente do agendamento';
+                } else if (item.resultado === 'pendente') {
+                    statusSpan.classList.add('pendente');
+                    textoStatus = item.mensagem || 'Informe a sala desejada';
+                } else {
+                    statusSpan.classList.add('pendente');
+                    if (item.mensagem) textoStatus = item.mensagem;
+                }
+                statusSpan.textContent = textoStatus;
+                tdStatus.appendChild(statusSpan);
+
+                const tdAcao = document.createElement('td');
+                const btn = document.createElement('button');
+                btn.type = 'button';
+                btn.className = 'btn btn-primary';
+                btn.dataset.planejamentoId = item.id;
+                btn.innerHTML = '<i class="fas fa-check"></i> Substituir';
+                btn.disabled = item.resultado !== 'erro';
+                btn.addEventListener('click', () => aplicarPlanejamentoLinha(item.id));
+                tdAcao.appendChild(btn);
+
+                tr.appendChild(tdProfissional);
+                tr.appendChild(tdEspecialidade);
+                tr.appendChild(tdTurno);
+                tr.appendChild(tdSalaAtual);
+                tr.appendChild(tdPlanejada);
+                tr.appendChild(tdStatus);
+                tr.appendChild(tdAcao);
+
+                tbody.appendChild(tr);
+            });
+
+            const possuiNaoTestado = estado.planejamentoLinhas.some(item => item.resultado === null);
+            if (feedback && possuiNaoTestado) {
+                feedback.textContent = 'Execute "Testar atribuições" para validar o planejamento.';
+                feedback.style.color = 'var(--text-secondary)';
+            }
+        }
+
+        function mostrarPlanejamentoMensagem(texto, sucesso = false, alerta = false) {
+            const feedback = document.getElementById('planejamento-feedback');
+            if (!feedback) return;
+            feedback.textContent = texto;
+            if (alerta) {
+                feedback.style.color = '#fecaca';
+            } else if (sucesso) {
+                feedback.style.color = '#bbf7d0';
+            } else {
+                feedback.style.color = 'var(--text-secondary)';
+            }
+        }
+
+        function testarPlanejamento() {
+            if (!Array.isArray(estado.planejamentoLinhas) || estado.planejamentoLinhas.length === 0) {
+                mostrarPlanejamentoMensagem('Nenhum agendamento para validar neste turno.', false, true);
+                return;
+            }
+
+            let corretos = 0;
+            let divergentes = 0;
+            let pendentes = 0;
+
+            estado.planejamentoLinhas.forEach(item => {
+                const planejada = (item.salaPlanejada || '').trim();
+                const atual = (item.salaAtual || '').trim();
+
+                if (!planejada) {
+                    item.resultado = 'pendente';
+                    item.mensagem = 'Informe a sala desejada';
+                    pendentes++;
+                    return;
+                }
+
+                if (planejada.toLowerCase() === atual.toLowerCase()) {
+                    item.resultado = 'ok';
+                    item.mensagem = 'Sala conferida com sucesso';
+                    corretos++;
+                } else {
+                    item.resultado = 'erro';
+                    item.mensagem = atual ? `Agendado na sala ${atual}` : 'Sem sala registrada';
+                    divergentes++;
+                }
+            });
+
+            renderPlanejamento();
+
+            const partes = [];
+            if (corretos > 0) partes.push(`${corretos} corret${corretos === 1 ? 'o' : 'os'}`);
+            if (divergentes > 0) partes.push(`${divergentes} divergênc${divergentes === 1 ? 'ia' : 'ias'}`);
+            if (pendentes > 0) partes.push(`${pendentes} pendente${pendentes === 1 ? '' : 's'}`);
+
+            const texto = partes.length > 0
+                ? `Resultado do teste: ${partes.join(' • ')}`
+                : 'Nenhuma sala planejada informada.';
+
+            mostrarPlanejamentoMensagem(texto, divergentes === 0 && pendentes === 0, divergentes > 0 || pendentes > 0);
+        }
+
+        function aplicarPlanejamentoLinha(id) {
+            const linha = estado.planejamentoLinhas.find(item => item.id === String(id));
+            if (!linha) {
+                mostrarPlanejamentoMensagem('Não foi possível localizar o agendamento selecionado.', false, true);
+                return;
+            }
+
+            if (linha.resultado !== 'erro') {
+                mostrarPlanejamentoMensagem('É necessário testar as atribuições antes de substituir.', false, true);
+                return;
+            }
+
+            const salaDestino = (linha.salaPlanejada || '').trim();
+            if (!salaDestino) {
+                mostrarPlanejamentoMensagem('Informe a sala desejada para continuar.', false, true);
+                return;
+            }
+
+            const btnLinha = document.querySelector(`button[data-planejamento-id="${linha.id}"]`);
+            if (btnLinha) btnLinha.disabled = true;
+
+            const salaInfo = estado.salas.find(s => String(s.numero).toLowerCase() === salaDestino.toLowerCase());
+            if (!salaInfo) {
+                if (btnLinha) btnLinha.disabled = false;
+                mostrarPlanejamentoMensagem('Sala destino não encontrada no cadastro. Verifique a numeração informada.', false, true);
+                return;
+            }
+
+            const payload = { sala: salaInfo.numero };
+            if (salaInfo.ilha) {
+                payload.ilha = salaInfo.ilha;
+            }
+
+            mostrarPlanejamentoMensagem('Aplicando substituição...', false);
+
+            google.script.run
+                .withSuccessHandler(result => {
+                    if (result.success) {
+                        mostrarPlanejamentoMensagem('Substituição realizada com sucesso. Atualizando dados...', true);
+                        carregarDados();
+                    } else {
+                        if (btnLinha) btnLinha.disabled = false;
+                        mostrarPlanejamentoMensagem(result.message || 'Não foi possível atualizar o agendamento.', false, true);
+                    }
+                })
+                .withFailureHandler(error => {
+                    if (btnLinha) btnLinha.disabled = false;
+                    mostrarPlanejamentoMensagem('Erro ao substituir: ' + error.toString(), false, true);
+                })
+                .atualizarAgendamento(linha.id, payload);
+        }
+
+        function aplicarPlanejamentoTudo() {
+            const divergentes = estado.planejamentoLinhas.filter(item => item.resultado === 'erro');
+            if (divergentes.length === 0) {
+                mostrarPlanejamentoMensagem('Nenhuma divergência para substituir. Execute o teste primeiro.', false, true);
+                return;
+            }
+
+            const aplicarBtn = document.getElementById('planejamento-aplicar');
+            if (aplicarBtn) aplicarBtn.disabled = true;
+
+            mostrarPlanejamentoMensagem(`Substituindo ${divergentes.length} registro${divergentes.length === 1 ? '' : 's'}...`, false);
+
+            const processar = (index) => {
+                if (index >= divergentes.length) {
+                    if (aplicarBtn) aplicarBtn.disabled = false;
+                    mostrarPlanejamentoMensagem('Substituições concluídas. Atualizando dados...', true);
+                    carregarDados();
+                    return;
+                }
+
+                const item = divergentes[index];
+                const salaDestino = (item.salaPlanejada || '').trim();
+                const salaInfo = estado.salas.find(s => String(s.numero).toLowerCase() === salaDestino.toLowerCase());
+                if (!salaInfo) {
+                    if (aplicarBtn) aplicarBtn.disabled = false;
+                    mostrarPlanejamentoMensagem(`Sala ${salaDestino} não encontrada no cadastro. Operação interrompida.`, false, true);
+                    return;
+                }
+
+                const payload = { sala: salaInfo.numero };
+                if (salaInfo.ilha) {
+                    payload.ilha = salaInfo.ilha;
+                }
+
+                google.script.run
+                    .withSuccessHandler(result => {
+                        if (result.success) {
+                            processar(index + 1);
+                        } else {
+                            if (aplicarBtn) aplicarBtn.disabled = false;
+                            mostrarPlanejamentoMensagem(result.message || 'Falha ao substituir um dos agendamentos.', false, true);
+                        }
+                    })
+                    .withFailureHandler(error => {
+                        if (aplicarBtn) aplicarBtn.disabled = false;
+                        mostrarPlanejamentoMensagem('Erro ao substituir: ' + error.toString(), false, true);
+                    })
+                    .atualizarAgendamento(item.id, payload);
+            };
+
+            processar(0);
+        }
+
         function criarElementoSala(sala, horarios) {
             const salaDiv = document.createElement('div');
             salaDiv.className = 'sala';
             salaDiv.setAttribute('data-sala', sala.numero);
-            
+
             // Determinar status geral da sala
             const statusNormalizado = sala.statusNormalizado || normalizarStatus(sala.statusGeral || sala.status);
             const statusClass = statusParaClasseVisual(statusNormalizado);
@@ -3383,6 +3988,9 @@
                             </div>
                         </div>
                         <div class="agendamento-actions admin-only">
+                            <button class="btn-editar" data-agendamento-id="${ag.id}">
+                                <i class="fas fa-user-edit"></i> Editar
+                            </button>
                             <button class="btn-mover" data-agendamento-id="${ag.id}">
                                 <i class="fas fa-exchange-alt"></i> Mover Sala
                             </button>
@@ -3401,6 +4009,13 @@
                     btn.addEventListener('click', function() {
                         const agId = this.getAttribute('data-agendamento-id');
                         abrirModalMover(agId, numeroSala);
+                    });
+                });
+                document.querySelectorAll('.btn-editar').forEach(btn => {
+                    btn.addEventListener('click', function(event) {
+                        event.stopPropagation();
+                        const agId = this.getAttribute('data-agendamento-id');
+                        abrirModalEditar(agId);
                     });
                 });
             }
@@ -3521,6 +4136,127 @@
             .atualizarAgendamento(estado.agendamentoMoverId, {sala: salaDestino, ilha: ilhaDestino});
     }
 }
+
+        function preencherOpcoesEditar() {
+            const editarEspecialidade = document.getElementById('editar-especialidade');
+            const editarCategoria = document.getElementById('editar-categoria');
+            if (editarEspecialidade && editarEspecialidade.options.length <= 1) {
+                editarEspecialidade.innerHTML = '<option value="">Selecione</option>';
+                estado.dadosMestres.especialidades.forEach(esp => {
+                    const option = document.createElement('option');
+                    option.value = esp;
+                    option.textContent = esp;
+                    editarEspecialidade.appendChild(option);
+                });
+            }
+            if (editarCategoria && editarCategoria.options.length <= 1) {
+                editarCategoria.innerHTML = '<option value="">Selecione</option>';
+                estado.dadosMestres.categorias.forEach(cat => {
+                    const option = document.createElement('option');
+                    option.value = cat;
+                    option.textContent = cat;
+                    editarCategoria.appendChild(option);
+                });
+            }
+        }
+
+        function abrirModalEditar(agendamentoId) {
+            const ag = estado.agendamentos.find(ag => String(ag.id) === String(agendamentoId));
+            if (!ag) {
+                alert('Agendamento não encontrado.');
+                return;
+            }
+
+            preencherOpcoesEditar();
+
+            estado.agendamentoEditarId = String(agendamentoId);
+
+            document.getElementById('editar-profissional').value = ag.profissional || '';
+            const editarEspecialidade = document.getElementById('editar-especialidade');
+            const editarCategoria = document.getElementById('editar-categoria');
+            if (ag.especialidade && editarEspecialidade && !Array.from(editarEspecialidade.options).some(opt => opt.value === ag.especialidade)) {
+                const option = document.createElement('option');
+                option.value = ag.especialidade;
+                option.textContent = ag.especialidade;
+                editarEspecialidade.appendChild(option);
+            }
+            if (ag.categoria && editarCategoria && !Array.from(editarCategoria.options).some(opt => opt.value === ag.categoria)) {
+                const option = document.createElement('option');
+                option.value = ag.categoria;
+                option.textContent = ag.categoria;
+                editarCategoria.appendChild(option);
+            }
+            document.getElementById('editar-especialidade').value = ag.especialidade || '';
+            document.getElementById('editar-categoria').value = ag.categoria || '';
+            document.getElementById('editar-status').value = normalizarStatus(ag.status);
+            document.getElementById('editar-turno').value = ag.turnoNormalizado || normalizarTurno(ag.turno) || 'manha';
+            document.getElementById('editar-hora-inicio').value = ag.horaInicio || '';
+            document.getElementById('editar-hora-fim').value = ag.horaFim || '';
+            document.getElementById('editar-observacoes').value = ag.observacoes || '';
+
+            const alerta = document.getElementById('editar-alert');
+            if (alerta) alerta.style.display = 'none';
+
+            document.getElementById('editar-modal').style.display = 'flex';
+        }
+
+        function salvarEdicaoAgendamento() {
+            if (!estado.agendamentoEditarId) {
+                mostrarEditarAlerta('Nenhum agendamento selecionado para edição.');
+                return;
+            }
+
+            const profissional = document.getElementById('editar-profissional').value.trim();
+            const especialidade = document.getElementById('editar-especialidade').value;
+            const categoria = document.getElementById('editar-categoria').value;
+            const status = document.getElementById('editar-status').value;
+            const turno = document.getElementById('editar-turno').value;
+            const horaInicio = document.getElementById('editar-hora-inicio').value;
+            const horaFim = document.getElementById('editar-hora-fim').value;
+            const observacoes = document.getElementById('editar-observacoes').value;
+
+            if (!profissional || !especialidade || !categoria || !status || !turno || !horaInicio || !horaFim) {
+                mostrarEditarAlerta('Preencha todos os campos obrigatórios.');
+                return;
+            }
+
+            const payload = {
+                profissional,
+                especialidade,
+                categoria,
+                status,
+                turno,
+                horaInicio,
+                horaFim,
+                observacoes
+            };
+
+            google.script.run
+                .withSuccessHandler(result => {
+                    if (result.success) {
+                        alert('Agendamento atualizado com sucesso!');
+                        estado.agendamentoEditarId = null;
+                        document.getElementById('editar-modal').style.display = 'none';
+                        carregarDados();
+                    } else {
+                        mostrarEditarAlerta(result.message || 'Não foi possível atualizar o agendamento.');
+                    }
+                })
+                .withFailureHandler(error => {
+                    mostrarEditarAlerta('Erro ao atualizar agendamento: ' + error.toString());
+                })
+                .atualizarAgendamento(estado.agendamentoEditarId, payload);
+        }
+
+        function mostrarEditarAlerta(mensagem) {
+            const alerta = document.getElementById('editar-alert');
+            if (!alerta) return;
+            document.getElementById('editar-message').textContent = mensagem;
+            alerta.style.display = 'block';
+            setTimeout(() => {
+                alerta.style.display = 'none';
+            }, 5000);
+        }
 
         function fecharModalsAndReload() {
             document.querySelectorAll('.modal').forEach(modal => modal.style.display = 'none');
@@ -3814,36 +4550,46 @@
             const ocupacaoGeral = informacoes.ocupacaoGeral || {};
             const statusDistribuicao = informacoes.statusDistribuicao || {};
 
-            // Limpar charts anteriores
+            const legendColor = '#dbe8ff';
+            const gridColor = 'rgba(255, 255, 255, 0.08)';
+            const tooltipConfig = {
+                enabled: true,
+                backgroundColor: 'rgba(13, 23, 46, 0.92)',
+                titleColor: '#f8fafc',
+                bodyColor: '#f8fafc',
+                borderWidth: 0
+            };
+
             ['turno', 'ilha', 'evolucao', 'especialidade', 'heatmap', 'aproveitamento'].forEach(id => {
                 const canvas = document.getElementById(`chart-${id}`);
-                if (canvas.chart) canvas.chart.destroy();
+                if (canvas && canvas.chart) canvas.chart.destroy();
             });
 
-            // Ocupação por Turno (Pie Chart)
             const ctxTurno = document.getElementById('chart-turno').getContext('2d');
             const turnosOrdem = ['manha', 'tarde', 'noite'];
             const turnosRotulos = ['Manhã', 'Tarde', 'Noite'];
             const dadosTurno = turnosOrdem.map(key => Number(ocupacaoTurno[key] || 0));
             document.getElementById('chart-turno').chart = new Chart(ctxTurno, {
-                type: 'pie',
+                type: 'doughnut',
                 data: {
                     labels: turnosRotulos,
                     datasets: [{
                         data: dadosTurno,
-                        backgroundColor: ['#48bb78', '#4299e1', '#f56565']
+                        backgroundColor: ['#4ade80', '#60a5fa', '#f97316'],
+                        borderWidth: 0
                     }]
                 },
                 options: {
                     responsive: true,
+                    maintainAspectRatio: false,
+                    cutout: '55%',
                     plugins: {
-                        legend: { position: 'top' },
-                        title: { display: true, text: 'Ocupação por Turno' }
+                        legend: { position: 'bottom', labels: { color: legendColor, usePointStyle: true } },
+                        tooltip: tooltipConfig
                     }
                 }
             });
 
-            // Ocupação por Ilha (Bar Chart)
             const ctxIlha = document.getElementById('chart-ilha').getContext('2d');
             const entradasIlhas = Object.entries(ocupacaoIlha).sort((a, b) => {
                 const numA = parseFloat(a[0]);
@@ -3866,16 +4612,25 @@
                     datasets: [{
                         label: 'Ocupação por Ilha',
                         data: dadosIlhas,
-                        backgroundColor: '#5b7cfd'
+                        backgroundColor: '#7a8dff',
+                        borderRadius: 6,
+                        maxBarThickness: 36
                     }]
                 },
                 options: {
                     responsive: true,
-                    scales: { y: { beginAtZero: true } }
+                    maintainAspectRatio: false,
+                    plugins: {
+                        legend: { display: false },
+                        tooltip: tooltipConfig
+                    },
+                    scales: {
+                        x: { ticks: { color: legendColor }, grid: { color: gridColor } },
+                        y: { beginAtZero: true, ticks: { color: legendColor }, grid: { color: gridColor } }
+                    }
                 }
             });
 
-            // Evolução de Ocupação (Line Chart)
             const ctxEvolucao = document.getElementById('chart-evolucao').getContext('2d');
             const evolucaoOrdenada = Object.entries(evolucao).sort((a, b) => new Date(a[0]) - new Date(b[0]));
             const labelsEvolucao = evolucaoOrdenada.length
@@ -3889,19 +4644,31 @@
                 data: {
                     labels: labelsEvolucao,
                     datasets: [{
-                        label: 'Evolução',
+                        label: 'Evolução de ocupação',
                         data: dadosEvolucao,
-                        borderColor: '#5b7cfd',
-                        tension: 0.1
+                        borderColor: '#60a5fa',
+                        backgroundColor: 'rgba(96, 165, 250, 0.15)',
+                        fill: true,
+                        tension: 0.35,
+                        pointRadius: 4,
+                        pointBackgroundColor: '#60a5fa',
+                        pointBorderWidth: 0
                     }]
                 },
                 options: {
                     responsive: true,
-                    scales: { y: { beginAtZero: true } }
+                    maintainAspectRatio: false,
+                    plugins: {
+                        legend: { display: false },
+                        tooltip: tooltipConfig
+                    },
+                    scales: {
+                        x: { ticks: { color: legendColor }, grid: { color: gridColor } },
+                        y: { beginAtZero: true, ticks: { color: legendColor }, grid: { color: gridColor } }
+                    }
                 }
             });
 
-            // Distribuição por Especialidade (Bar Chart)
             const ctxEspecialidade = document.getElementById('chart-especialidade').getContext('2d');
             const entradasEspecialidades = Object.entries(especialidades).sort((a, b) => b[1] - a[1]);
             const labelsEspecialidades = entradasEspecialidades.length
@@ -3915,18 +4682,28 @@
                 data: {
                     labels: labelsEspecialidades,
                     datasets: [{
-                        label: 'Por Especialidade',
+                        label: 'Agendamentos',
                         data: dadosEspecialidades,
-                        backgroundColor: '#8a4dbf'
+                        backgroundColor: '#a855f7',
+                        borderRadius: 6,
+                        maxBarThickness: 32
                     }]
                 },
                 options: {
+                    indexAxis: 'y',
                     responsive: true,
-                    scales: { y: { beginAtZero: true } }
+                    maintainAspectRatio: false,
+                    plugins: {
+                        legend: { display: false },
+                        tooltip: tooltipConfig
+                    },
+                    scales: {
+                        x: { beginAtZero: true, ticks: { color: legendColor }, grid: { color: gridColor } },
+                        y: { ticks: { color: legendColor }, grid: { color: 'rgba(0,0,0,0)' } }
+                    }
                 }
             });
 
-            // Distribuição geral de ocupação (Doughnut)
             const ctxHeatmap = document.getElementById('chart-heatmap').getContext('2d');
             const labelsGeral = ['Uso médio', 'Salas livres', 'Indisponíveis'];
             const dadosGeral = [
@@ -3940,15 +4717,21 @@
                     labels: labelsGeral,
                     datasets: [{
                         data: dadosGeral,
-                        backgroundColor: ['#f56565', '#48bb78', '#f59e0b']
+                        backgroundColor: ['#7a8dff', '#4ade80', '#fbbf24'],
+                        borderWidth: 0
                     }]
                 },
                 options: {
-                    responsive: true
+                    responsive: true,
+                    maintainAspectRatio: false,
+                    cutout: '60%',
+                    plugins: {
+                        legend: { position: 'bottom', labels: { color: legendColor, usePointStyle: true } },
+                        tooltip: tooltipConfig
+                    }
                 }
             });
 
-            // Distribuição por status (Polar Area)
             const ctxAproveitamento = document.getElementById('chart-aproveitamento').getContext('2d');
             const entradasStatus = Object.entries(statusDistribuicao).sort((a, b) => b[1] - a[1]);
             const statusLabels = entradasStatus.length
@@ -3957,7 +4740,7 @@
             const statusValores = entradasStatus.length
                 ? entradasStatus.map(([, valor]) => Number(valor) || 0)
                 : [0];
-            const statusCores = ['#5b7cfd', '#48bb78', '#f59e0b', '#f56565', '#38bdf8', '#9f7aea'];
+            const statusCores = ['#7a8dff', '#4ade80', '#f97316', '#f87171', '#60a5fa', '#a855f7'];
             document.getElementById('chart-aproveitamento').chart = new Chart(ctxAproveitamento, {
                 type: 'polarArea',
                 data: {
@@ -3968,7 +4751,19 @@
                     }]
                 },
                 options: {
-                    responsive: true
+                    responsive: true,
+                    maintainAspectRatio: false,
+                    plugins: {
+                        legend: { position: 'bottom', labels: { color: legendColor, usePointStyle: true } },
+                        tooltip: tooltipConfig
+                    },
+                    scales: {
+                        r: {
+                            grid: { color: gridColor },
+                            angleLines: { color: gridColor },
+                            ticks: { display: false }
+                        }
+                    }
                 }
             });
         }


### PR DESCRIPTION
## Summary
- add the planning workspace to compare desired room assignments with live bookings and enable one-click substitutions when mismatches are found
- streamline the monitor by removing the side indicators, lightening status colours, defaulting the status filter to livre/ocupado and introducing inline editing for agendamentos
- redesign dashboard visuals with a compact grid layout and refreshed Chart.js styles for better readability

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_b_68e555e513788332ac2f3dd2945ed8c7