### PR TITLE
Improve responsiveness for monitor and planning screens

### DIFF
--- a/Index.html
+++ b/Index.html
@@ -441,11 +441,11 @@
           background: var(--surface-base);
           border-radius: var(--radius-md);
           border: 1px solid var(--border-soft);
-          padding: 24px;
+          padding: 28px;
           box-shadow: var(--shadow-soft);
           display: flex;
           flex-direction: column;
-          gap: 16px;
+          gap: 20px;
       }
 
       .planejamento-header {
@@ -472,6 +472,7 @@
           gap: 12px;
           align-items: center;
           flex-wrap: wrap;
+          justify-content: flex-end;
       }
 
       .planejamento-controls label {
@@ -491,7 +492,8 @@
       }
 
       .planejamento-table-wrapper {
-          max-height: 320px;
+          max-height: 65vh;
+          min-height: 280px;
           overflow: auto;
           border-radius: var(--radius-sm);
           border: 1px solid var(--border-soft);
@@ -499,6 +501,7 @@
 
       .planejamento-table {
           width: 100%;
+          min-width: 780px;
           border-collapse: collapse;
           color: var(--text-secondary);
           font-size: 0.92rem;
@@ -665,20 +668,61 @@
           to { transform: rotate(360deg); }
       }
 
+      .monitor-scroll {
+          width: 100%;
+          overflow-x: auto;
+          padding-bottom: 6px;
+      }
+
+      .monitor-scroll::-webkit-scrollbar {
+          height: 8px;
+      }
+
+      .monitor-scroll::-webkit-scrollbar-thumb {
+          background: rgba(148, 163, 254, 0.4);
+          border-radius: 999px;
+      }
+
+      .monitor-scroll::-webkit-scrollbar-track {
+          background: rgba(15, 23, 42, 0.35);
+      }
+
       #monitor-content {
           display: grid;
-          grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+          grid-template-columns: repeat(auto-fit, minmax(340px, 1fr));
           gap: 18px;
+      }
+
+      @media (max-width: 1400px) {
+          #monitor-content {
+              grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+          }
+      }
+
+      @media (max-width: 1100px) {
+          #monitor-content {
+              grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+          }
       }
 
       .planta-container {
           display: grid;
-          grid-template-columns: repeat(auto-fit, minmax(80px, 1fr));
-          gap: 8px;
-          padding: 12px;
+          grid-template-columns: repeat(auto-fill, minmax(110px, 1fr));
+          gap: 12px;
+          padding: 16px;
           background: var(--surface-elevated);
           border-radius: var(--radius-sm);
           border: 1px solid var(--border-soft);
+          overflow-x: auto;
+      }
+
+      .planta-container::-webkit-scrollbar {
+          height: 8px;
+      }
+
+      .planta-container::-webkit-scrollbar-thumb {
+          background: rgba(148, 163, 254, 0.35);
+          border-radius: 999px;
       }
 
       .planta-cell {
@@ -721,6 +765,7 @@
           border-radius: var(--radius-sm);
           border: 1px solid var(--border-soft);
           padding: 18px;
+          min-width: 280px;
       }
 
       .bloco h3 {
@@ -1403,6 +1448,14 @@
               overflow-y: auto;
           }
 
+          .planejamento-container {
+              padding: 22px;
+          }
+
+          .planejamento-controls {
+              justify-content: flex-start;
+          }
+
           .sidebar.drawer-open {
               transform: translateX(0);
           }
@@ -1461,8 +1514,53 @@
               width: 100%;
           }
 
+          .monitor-scroll {
+              padding-bottom: 0;
+          }
+
           #monitor-content {
-              grid-template-columns: 1fr;
+              grid-template-columns: minmax(0, 1fr);
+              min-width: 100%;
+          }
+
+          .bloco {
+              min-width: 100%;
+          }
+
+          .planejamento-container {
+              padding: 18px;
+          }
+
+          .planejamento-header {
+              flex-direction: column;
+              align-items: flex-start;
+              gap: 12px;
+          }
+
+          .planejamento-controls {
+              width: 100%;
+              flex-direction: column;
+              align-items: stretch;
+          }
+
+          .planejamento-controls label,
+          .planejamento-controls button {
+              width: 100%;
+          }
+
+          .planejamento-table-wrapper {
+              max-height: none;
+              overflow-x: auto;
+          }
+
+          .planejamento-table {
+              min-width: 640px;
+              font-size: 0.88rem;
+          }
+
+          .planejamento-table th,
+          .planejamento-table td {
+              padding: 12px 12px;
           }
       }
 
@@ -1644,7 +1742,8 @@
                         <p>Carregando salas...</p>
                     </div>
 
-                    <div class="monitor" id="monitor-content">
+                    <div class="monitor-scroll">
+                        <div class="monitor" id="monitor-content"></div>
                     </div>
                 </div>
 


### PR DESCRIPTION
## Summary
- add a horizontal scroll wrapper and wider column defaults to keep monitor cards readable with many salas
- expand and make the planning table container adaptive with larger heights and mobile-friendly controls
- adjust plant visualization spacing and enable scrolling for dense layouts

## Testing
- Manual verification: opened Index.html locally via a Python HTTP server

------
https://chatgpt.com/codex/tasks/task_b_68e56a5d7cdc83329034063813eeb7fa