### PR TITLE
Restore horizontal scroll in island monitor view

### DIFF
--- a/Index.html
+++ b/Index.html
@@ -689,19 +689,22 @@
 
       #monitor-content {
           display: grid;
-          grid-template-columns: repeat(auto-fit, minmax(340px, 1fr));
+          grid-auto-flow: column;
+          grid-auto-columns: minmax(340px, 1fr);
           gap: 18px;
+          width: max-content;
+          min-width: 100%;
       }
 
       @media (max-width: 1400px) {
           #monitor-content {
-              grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+              grid-auto-columns: minmax(300px, 1fr);
           }
       }
 
       @media (max-width: 1100px) {
           #monitor-content {
-              grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+              grid-auto-columns: minmax(260px, 1fr);
           }
       }
 
@@ -1519,8 +1522,11 @@
           }
 
           #monitor-content {
+              grid-auto-flow: row;
+              grid-auto-columns: unset;
               grid-template-columns: minmax(0, 1fr);
-              min-width: 100%;
+              width: 100%;
+              min-width: unset;
           }
 
           .bloco {


### PR DESCRIPTION
## Summary
- adjust the monitor content grid to flow horizontally with fixed column widths so excess islands remain accessible via scrolling
- maintain responsive behaviour by falling back to a single-column layout on narrow screens

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e56d5053ac8332925618dd62077ec8