### PR TITLE
Ajusta layout das ilhas no monitor

### DIFF
--- a/Index.html
+++ b/Index.html
@@ -683,27 +683,41 @@
           border-radius: 999px;
       }
 
-      #monitor-content {
+      .monitor {
           display: flex;
-          flex-wrap: wrap;
           gap: 18px;
+          justify-content: space-between;
+          align-items: stretch;
+          min-height: 65vh;
+          height: 75vh;
           width: 100%;
-          justify-content: flex-start;
       }
 
-      #monitor-content > .bloco {
-          flex: 0 0 320px;
+      .monitor > .bloco {
+          flex: 1;
+          display: flex;
+          flex-direction: column;
+          min-width: 0;
+      }
+
+      .monitor > .planta-container {
+          flex: 1 1 100%;
       }
 
       @media (max-width: 1400px) {
-          #monitor-content > .bloco {
-              flex-basis: 300px;
+          .monitor {
+              gap: 16px;
           }
       }
 
       @media (max-width: 1100px) {
-          #monitor-content > .bloco {
-              flex-basis: 260px;
+          .monitor {
+              flex-wrap: wrap;
+              min-height: auto;
+          }
+
+          .monitor > .bloco {
+              flex: 1 1 260px;
           }
       }
 
@@ -768,6 +782,7 @@
           border: 1px solid var(--border-soft);
           padding: 18px;
           min-width: 280px;
+          min-height: 0;
       }
 
       .bloco h3 {
@@ -783,9 +798,10 @@
           display: flex;
           flex-direction: column;
           gap: 12px;
-          max-height: 520px;
+          flex: 1;
           overflow-y: auto;
-          padding-right: 6px;
+          padding-right: 8px;
+          min-height: 0;
       }
 
       .sala {
@@ -1520,11 +1536,12 @@
               padding-bottom: 0;
           }
 
-          #monitor-content {
+          .monitor {
               flex-direction: column;
+              min-height: auto;
           }
 
-          #monitor-content > .bloco {
+          .monitor > .bloco {
               flex: 1 1 auto;
           }
 
@@ -2660,7 +2677,7 @@
 
         function esconderLoading() {
             document.getElementById('loading-monitor').style.display = 'none';
-            document.getElementById('monitor-content').style.display = 'grid';
+            document.getElementById('monitor-content').style.display = 'flex';
         }
 
         function carregarDadosMestres() {


### PR DESCRIPTION
## Summary
- restaura o layout em colunas do monitor usando o estilo de referência do exemplo
- ajusta os contêineres de salas e planta para preencherem a altura do monitor e suportarem rolagem
- garante que o monitor retorne para display flex ao finalizar o carregamento

## Testing
- não aplicável

------
https://chatgpt.com/codex/tasks/task_b_68e644acd2708332a9a099a0c179e22b