### PR TITLE
Fix mobile navigation overlay interaction

### DIFF
--- a/style.html
+++ b/style.html
@@ -254,7 +254,7 @@
           position: relative;
           flex-wrap: nowrap;
           width: 100%;
-          z-index: 30;
+          z-index: 980;
       }
 
       .header-utilities {
@@ -666,6 +666,8 @@
           transition: var(--transition-fast);
           box-shadow: var(--shadow-soft);
           white-space: nowrap;
+          position: relative;
+          z-index: 980;
       }
 
       .nav-toggle i {


### PR DESCRIPTION
## Summary
- raise the header navigation stacking context so the mobile menu renders above the drawer backdrop
- keep the mobile menu toggle button accessible by lifting it above the backdrop layer

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_b_690b516074b08332ad0f441823519fc7